### PR TITLE
Patch for RT #29928 Allows precompiled templates to be properly filled in with a preprocessor

### DIFF
--- a/lib/Text/Template.pm
+++ b/lib/Text/Template.pm
@@ -131,10 +131,10 @@ sub source {
 }
 
 sub set_source_data {
-  my ($self, $newdata) = @_;
+  my ($self, $newdata, $type) = @_;
   $self->{SOURCE} = $newdata;
   $self->{DATA_ACQUIRED} = 1;
-  $self->{TYPE} = 'STRING';
+  $self->{TYPE} = $type || 'STRING';
   1;
 }
 

--- a/lib/Text/Template/Preprocess.pm
+++ b/lib/Text/Template/Preprocess.pm
@@ -12,10 +12,11 @@ sub fill_in {
   my $pp = $args{PREPROCESSOR} || $self->{PREPROCESSOR} ;
   if ($pp) {
     local $_ = $self->source();
+    my $type = $self->{TYPE};
 #    print "# fill_in: before <$_>\n";
     &$pp;
 #    print "# fill_in: after <$_>\n";
-    $self->set_source_data($_);
+    $self->set_source_data($_, $type);
   }
   $self->SUPER::fill_in(@_);
 }

--- a/t/15-rt29928.t
+++ b/t/15-rt29928.t
@@ -1,0 +1,28 @@
+#!perl
+#
+# Test for RT Bug 29928 fix
+# https://rt.cpan.org/Public/Bug/Display.html?id=29928
+
+use Text::Template::Preprocess;
+
+print "1..1\n";
+my $n = 1;
+
+my $tin = q{The value of $foo is: {$foo}.};
+
+sub tester {
+  1; #dummy preprocessor to cause the bug described.
+}
+
+$tmpl1 = Text::Template::Preprocess->new(TYPE => 'STRING',
+  SOURCE => $tin,
+);
+$tmpl1->compile;
+$t1 = $tmpl1->fill_in(
+  HASH => {foo => 'things'},
+  PREPROCESSOR => \&tester,
+);
+
+($t1 eq 'The value of $foo is: things.') or print "not ";
+print "ok $n\n"; $n++;
+


### PR DESCRIPTION
Added the patch from RT #29928: https://rt.cpan.org/Public/Bug/Display.html?id=29928 with a test case. Allows precompiled templates to be properly filled in with a preprocessor. Credit to original patch author, I just brought it over to GitHub to make things easier. Thanks!

#cpan-prc #team-ziprecruiter