### PR TITLE
Fix for taint error under windows strawberry

### DIFF
--- a/t/taint.t
+++ b/t/taint.t
@@ -9,7 +9,7 @@ use File::Temp;
 
 use_ok 'Text::Template' or exit 1;
 
-my $tmpfile = File::Temp->new;
+my $tmpfile = File::Temp->new( $^O eq 'MSWin32' ? (DIR => '.') : () );
 my $file    = $tmpfile->filename;
 
 # makes its arguments tainted


### PR DESCRIPTION
`File::Temp` seems to be trying to create a temp directory in `\` and this is giving a permission denied error.  Setting the temp directory to `.` fixes this.

This fixes #12.  Alternative fixes might be worth considering:

 1. use `$ENV{TMP}` as the temp directory on windows.  This will need to be untainted though.