### PR TITLE
skip taint tests if running under a perl without taint support

### DIFF
--- a/t/taint.t
+++ b/t/taint.t
@@ -4,8 +4,16 @@
 use strict;
 use warnings;
 use lib 'blib/lib';
-use Test::More tests => 21;
+use Test::More;
 use File::Temp;
+use Config;
+
+if (exists($Config{taint_support}) && not $Config{taint_support}) {
+    plan skip_all => "your perl was built without taint support";
+}
+else {
+    plan tests => 21;
+}
 
 use_ok 'Text::Template' or exit 1;
 


### PR DESCRIPTION
Hi,

Perl 5.36.0 will support a Configure option for disabling taint support. This will give a performance boost, for people who never use taint anyway. When built this way, the taint features (e.g. -T and -t) silently do nothing.

This PR skips the taint tests if being run under a perl that was built without taint support.

If you want to test this, you can download 5.35.11 and build a taint-free perl with:

    ./Configure -Dusedevel -des -Utaint_support

Without this change, if someone builds a taint-free perl they won't be able to install Text::Template, as the testsuite will fail.

Cheers,
Neil
